### PR TITLE
DEPLOY-646: Change default mountPath of activemq to /opt/activemq/data

### DIFF
--- a/helm/activemq/values.yaml
+++ b/helm/activemq/values.yaml
@@ -44,5 +44,5 @@ livenessProbe:
 
 persistence:
   existingClaim: "alfresco-volume-claim"
-  mountPath: "/data"
+  mountPath: "/opt/activemq/data"
   subPath: "alfresco-infrastructure/activemq-data"


### PR DESCRIPTION
 Changed the default mountPath of activemq to `/opt/activemq/data` 