### PR TITLE
fix: externalize values for init container image repository and tag 

### DIFF
--- a/helm/activemq/templates/deployment-activemq.yaml
+++ b/helm/activemq/templates/deployment-activemq.yaml
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       initContainers:
         - name: init-fs
-          image: busybox
+          image: {{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}
           # command to allow repository to write to EFS volume.
           command: ["sh", "-c", "chown -R 33031:1000 {{ .Values.persistence.mountPath }}"]
           volumeMounts:

--- a/helm/activemq/values.yaml
+++ b/helm/activemq/values.yaml
@@ -2,6 +2,10 @@ image:
   repository: alfresco/alfresco-activemq
   tag: 5.15.8-java-8-oracle-centos-7-87b15e37ce8b
   pullPolicy: Always
+initContainer:
+  image:
+    repository: busybox
+    tag: latest
 adminUser:
   username: admin
   password: admin


### PR DESCRIPTION
This PR externalizes init containers Docker image and tag values for ActiveMq deployment. This is needed to be able to override image repository for deployments that use organization's private Docker registry instead of public Docker Hub or Alfresco Quay.io.